### PR TITLE
Fix Purge Assistant Not Properly Purging With VATUSA

### DIFF
--- a/actions/controller.ts
+++ b/actions/controller.ts
@@ -8,6 +8,10 @@ import {sendRosterRemovalEmail} from "@/actions/mail/controller";
 import {getServerSession, User} from "next-auth";
 import {authOptions} from "@/auth/auth";
 
+function wait(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 export const purgeControllers = async (ids: string[]) => {
 
     const session = await getServerSession(authOptions);
@@ -45,6 +49,7 @@ export const purgeControllers = async (ids: string[]) => {
         await log("DELETE", "USER", `Purged user ${user.firstName} ${user.lastName} (${user.cid}) from roster.`);
         await removeVatusaController(session.user, user.cid, user.controllerStatus === "VISITOR");
         await sendRosterRemovalEmail(user as User);
+        await wait(500);
     }
 
     revalidatePath("/controllers/roster", "layout");

--- a/app/admin/purge-assistant/page.tsx
+++ b/app/admin/purge-assistant/page.tsx
@@ -36,6 +36,18 @@ export default async function Page(
             controllerStatus: {
                 not: "NONE",
             },
+            OR: [
+            { 
+                rating: { 
+                    not: 0 
+                } 
+            },
+            {
+                rating: 0,
+                trainingAssignmentRequestStudentId: null,
+                trainingAssignmentStudentId: null,
+            },
+            ],
             ...(includeLoas === 'false' && {
                 OR: [
                     {

--- a/app/api/update/events/route.ts
+++ b/app/api/update/events/route.ts
@@ -9,8 +9,8 @@ const ut = new UTApi();
 
 export async function GET() {
 
-    const in24Hours = new Date();
-    in24Hours.setHours(in24Hours.getHours() + 24);
+    const in1Hour = new Date();
+    in1Hour.setHours(in1Hour.getHours() + 1)
 
     const oneDayAgo = new Date();
     oneDayAgo.setHours(oneDayAgo.getHours() - 24);
@@ -19,7 +19,7 @@ export async function GET() {
         where: {
             manualPositionsOpen: false,
             start: {
-                lte: in24Hours,
+                lte: in1Hour,
             },
             positionsLocked: false,
         },


### PR DESCRIPTION
This PR:

- Closes #40 
- Adds a throttle to the DELETE requests sent to VATUSA by the purge assistant
- Ensure observers are exempt from the training requirement so long as they have a training request or have been assigned a trainer